### PR TITLE
Add openshift template

### DIFF
--- a/rahti-ml-example-template.yaml
+++ b/rahti-ml-example-template.yaml
@@ -138,13 +138,13 @@ parameters:
   value: rahti-ml-examples
   required: true
 
-- description: The URL of repository with the application code. 
+- description: The URL of repository with the application code (change the default only if you know what you are doing). 
   displayName: Source Repository URL
   name: SOURCE_REPOSITORY_URL
   value: https://github.com/CSCfi/rahti-ml-examples 
   required: true
 
-- description: The branch of the source repository. 
+- description: The branch of the source repository (tf2-imdb, onnx-imdb). 
   displayName: Source Repository Branch
   name: SOURCE_REPOSITORY_REF
   value: tf2-imdb 

--- a/rahti-ml-example-template.yaml
+++ b/rahti-ml-example-template.yaml
@@ -125,6 +125,9 @@ objects:
       port: 8080
       protocol: TCP
       targetPort: 8080
+    selector:
+      deploymentconfig: ${NAME}-dc
+
 
 ####################
 

--- a/rahti-ml-example-template.yaml
+++ b/rahti-ml-example-template.yaml
@@ -1,0 +1,154 @@
+apiVersion: v1
+kind: Template
+labels:
+  app: ${NAME}
+  template: ${NAME}
+message: |-
+  A simple Machine Learning example (sentiment detection) service has been scheduled for creation in your project, and should be soon available at: https://${NAME}.${APPLICATION_DOMAIN_SUFFIX}
+  Building images takes some minutes to complete, so please be patient. You can follow progress on your projects overview page.
+metadata:
+  annotations:
+    description: This template deploys A simple Machine Learning (sentiment detection) service.
+    iconClass: fa fa-robot
+    openshift.io/display-name: ML Example
+    openshift.io/documentation-url: https://github.com/tdeneke/rahti-ml-examples
+    openshift.io/support-url: https://www.csc.fi/contact-info
+    openshift.io/long-description: 
+    openshift.io/provider-display-name: CSC
+    tags: rahti-ml-examples
+    template.openshift.io/bindable: "false"
+  name: rahti-ml-examples
+
+objects:
+- apiVersion: build.openshift.io/v1
+  kind: BuildConfig
+  metadata:
+    annotations:
+      description: Defines how the service is built.
+    labels:
+      app: ${NAME}
+    name: ${NAME}-bc 
+  spec:
+    output:
+      to:
+        kind: ImageStreamTag
+        name: ${NAME}:latest
+    source:
+      git:
+        ref: ${SOURCE_REPOSITORY_REF}
+        uri: ${SOURCE_REPOSITORY_URL}
+      type: Git
+    strategy:
+      sourceStrategy:
+        from:
+          kind: ImageStreamTag
+          name: python:3.8
+          namespace: openshift
+      type: Source
+    triggers:
+    - type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: image.openshift.io/v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      description: Reference for latest service image.
+    labels:
+      app: ${NAME} 
+    name: ${NAME}
+
+- apiVersion: apps.openshift.io/v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      description: Defines how the service is deployed.
+    labels:
+      app: ${NAME} 
+    name: ${NAME}-dc
+  spec:
+    replicas: 1
+    strategy:
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: ${NAME} 
+      spec:
+        containers:
+        - name: ${NAME} 
+          image: ${NAME}:latest 
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          resources: {}
+    triggers:
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - ${NAME} 
+        from:
+          kind: ImageStreamTag
+          name: ${NAME}:latest
+      type: ImageChange
+    - type: ConfigChange
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    annotations:
+      description: Exposes the services to public.    
+    labels:
+      app: ${NAME} 
+    name: ${NAME}-route 
+  spec:
+    port:
+      targetPort: 8080-tcp
+    to:
+      kind: Service
+      name: ${NAME}-srv
+      weight: 100
+    wildcardPolicy: None
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      description: Defines an internal proxy. 
+    labels:
+      app: ${NAME} 
+    name: ${NAME}-srv 
+  spec:
+    ports:
+    - name: 8080-tcp
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+
+####################
+
+parameters:
+- description: Unique identifier for your application. 
+  displayName: Application Name
+  name: NAME
+  value: rahti-ml-examples
+  required: true
+
+- description: The URL of repository with the application code. 
+  displayName: Source Repository URL
+  name: SOURCE_REPOSITORY_URL
+  value: https://github.com/tdeneke/rahti-ml-examples 
+  required: true
+
+- description: The branch of the source repository. 
+  displayName: Source Repository Branch
+  name: SOURCE_REPOSITORY_REF
+  value: tf2-imdb 
+  required: true
+
+- description: The exposed hostname suffix that will be used to create routes for app
+  displayName: Application Hostname Suffix
+  name: APPLICATION_DOMAIN_SUFFIX
+  required: true
+  value: rahtiapp.fi

--- a/rahti-ml-example-template.yaml
+++ b/rahti-ml-example-template.yaml
@@ -11,7 +11,7 @@ metadata:
     description: This template deploys A simple Machine Learning (sentiment detection) service.
     iconClass: fa fa-robot
     openshift.io/display-name: ML Example
-    openshift.io/documentation-url: https://github.com/tdeneke/rahti-ml-examples
+    openshift.io/documentation-url: https://github.com/CSCfi/rahti-ml-examples 
     openshift.io/support-url: https://www.csc.fi/contact-info
     openshift.io/long-description: 
     openshift.io/provider-display-name: CSC
@@ -141,7 +141,7 @@ parameters:
 - description: The URL of repository with the application code. 
   displayName: Source Repository URL
   name: SOURCE_REPOSITORY_URL
-  value: https://github.com/tdeneke/rahti-ml-examples 
+  value: https://github.com/CSCfi/rahti-ml-examples 
   required: true
 
 - description: The branch of the source repository. 


### PR DESCRIPTION
A simple open shift template to build and deploy on Rahti. Can be useful as a base/example template for future 
deployments. 

Test with:
`
oc login ...
oc process -f rahti-ml-example-template.yaml | oc apply -f -
`

Clean up:
`oc delete all --selector app=rahti-ml-examples`